### PR TITLE
Add multi-page analytics dashboard demo site

### DIFF
--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1,0 +1,543 @@
+import { dashboardMetrics, salesData, usersData, reportsData } from './data.js';
+
+const chartInstances = {};
+
+const colors = {
+    primary: '#38bdf8',
+    secondary: '#818cf8',
+    tertiary: '#34d399',
+    muted: 'rgba(148, 163, 184, 0.35)'
+};
+
+function qs(selector) {
+    return document.querySelector(selector);
+}
+
+function qsa(selector) {
+    return Array.from(document.querySelectorAll(selector));
+}
+
+function setActiveNav(pathname) {
+    const links = qsa('.nav-links a');
+    links.forEach(link => {
+        const isActive = link.getAttribute('href').includes(pathname);
+        link.classList.toggle('active', isActive);
+    });
+}
+
+function renderMetricCards() {
+    const metricElements = qsa('[data-metric]');
+    metricElements.forEach(card => {
+        const key = card.dataset.metric;
+        const metric = dashboardMetrics[key];
+        if (!metric) return;
+
+        const valueEl = card.querySelector('.metric-value');
+        const changeEl = card.querySelector('.metric-change span.value');
+        const badgeEl = card.querySelector('.metric-change span.badge');
+
+        if (valueEl) {
+            valueEl.textContent = metric.value;
+        }
+
+        if (changeEl) {
+            changeEl.textContent = `${metric.change > 0 ? '+' : ''}${metric.change}%`;
+        }
+
+        if (badgeEl) {
+            badgeEl.textContent = metric.change > 0 ? 'Artış' : 'Düşüş';
+        }
+
+        const changeWrapper = card.querySelector('.metric-change');
+        changeWrapper?.classList.toggle('negative', metric.change < 0);
+
+        const ctx = card.querySelector('canvas');
+        if (ctx) {
+            createSparkline(ctx, metric.trend, metric.change < 0 ? colors.secondary : colors.primary);
+        }
+    });
+}
+
+function createSparkline(canvas, data, color) {
+    const id =
+        canvas.dataset.chartId || (window.crypto?.randomUUID?.() ?? `chart-${Math.random().toString(16).slice(2)}`);
+    canvas.dataset.chartId = id;
+    if (chartInstances[id]) {
+        chartInstances[id].destroy();
+    }
+
+    chartInstances[id] = new Chart(canvas, {
+        type: 'line',
+        data: {
+            labels: data.map((_, index) => index + 1),
+            datasets: [
+                {
+                    data,
+                    borderColor: color,
+                    borderWidth: 2,
+                    fill: true,
+                    backgroundColor: `${color}33`,
+                    pointRadius: 0,
+                    tension: 0.4
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: { enabled: false }
+            },
+            scales: {
+                x: { display: false },
+                y: { display: false }
+            }
+        }
+    });
+}
+
+function renderDashboard() {
+    const revenueCanvas = qs('#revenueChart');
+    if (!revenueCanvas) return;
+
+    new Chart(revenueCanvas, {
+        type: 'line',
+        data: {
+            labels: salesData.categories,
+            datasets: [
+                {
+                    label: 'Online Gelir',
+                    data: salesData.revenueByChannel.online,
+                    borderColor: colors.primary,
+                    backgroundColor: `${colors.primary}33`,
+                    tension: 0.4,
+                    fill: true
+                },
+                {
+                    label: 'Mağaza Geliri',
+                    data: salesData.revenueByChannel.retail,
+                    borderColor: colors.secondary,
+                    backgroundColor: `${colors.secondary}33`,
+                    tension: 0.4,
+                    fill: true
+                }
+            ]
+        },
+        options: {
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    labels: {
+                        color: '#e2e8f0'
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.1)' }
+                },
+                y: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.1)' }
+                }
+            }
+        }
+    });
+
+    const conversionCanvas = qs('#conversionChart');
+    new Chart(conversionCanvas, {
+        type: 'bar',
+        data: {
+            labels: ['Organik', 'Reklam', 'Referans', 'Etkinlik'],
+            datasets: [
+                {
+                    label: 'Dönüşüm',
+                    data: [4.6, 5.1, 3.8, 6.2],
+                    backgroundColor: [colors.primary, colors.secondary, colors.primary, colors.tertiary],
+                    borderRadius: 8,
+                    maxBarThickness: 36
+                }
+            ]
+        },
+        options: {
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false }
+            },
+            scales: {
+                x: {
+                    ticks: { color: colors.muted },
+                    grid: { display: false }
+                },
+                y: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.1)' }
+                }
+            }
+        }
+    });
+
+    const tableBody = qs('#topCustomers tbody');
+    const customers = [
+        { name: 'NovaTech', plan: 'Kurumsal', mrr: '$9,800', activity: '1 saat önce', status: 'Aktif' },
+        { name: 'DataFlow', plan: 'KOBİ', mrr: '$4,600', activity: '18 dk önce', status: 'Aktif' },
+        { name: 'Visionary Labs', plan: 'Startup', mrr: '$2,950', activity: '26 dk önce', status: 'İşlemde' },
+        { name: 'QuantumSoft', plan: 'Kurumsal', mrr: '$11,200', activity: '2 saat önce', status: 'Risk' }
+    ];
+
+    if (tableBody) {
+        tableBody.innerHTML = customers
+            .map(
+                customer => `
+                <tr>
+                    <td>${customer.name}</td>
+                    <td>${customer.plan}</td>
+                    <td>${customer.mrr}</td>
+                    <td>${customer.activity}</td>
+                    <td>
+                        <span class="status-badge ${
+                            customer.status === 'Aktif' ? 'success' : customer.status === 'Risk' ? 'danger' : 'warning'
+                        }">${customer.status}</span>
+                    </td>
+                </tr>
+            `
+            )
+            .join('');
+    }
+}
+
+function renderSalesPage() {
+    const revenueBreakdownCanvas = qs('#channelBreakdown');
+    if (!revenueBreakdownCanvas) return;
+
+    new Chart(revenueBreakdownCanvas, {
+        type: 'bar',
+        data: {
+            labels: salesData.categories,
+            datasets: [
+                {
+                    label: 'Online',
+                    data: salesData.revenueByChannel.online,
+                    backgroundColor: `${colors.primary}aa`
+                },
+                {
+                    label: 'Mağaza',
+                    data: salesData.revenueByChannel.retail,
+                    backgroundColor: `${colors.secondary}aa`
+                }
+            ]
+        },
+        options: {
+            maintainAspectRatio: false,
+            responsive: true,
+            plugins: {
+                legend: {
+                    labels: { color: '#e2e8f0' }
+                }
+            },
+            scales: {
+                x: {
+                    ticks: { color: colors.muted },
+                    grid: { display: false }
+                },
+                y: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.08)' }
+                }
+            }
+        }
+    });
+
+    const pipelineCanvas = qs('#pipelineChart');
+    new Chart(pipelineCanvas, {
+        type: 'bar',
+        data: {
+            labels: salesData.pipeline.map(item => item.stage),
+            datasets: [
+                {
+                    label: 'Fırsat Adedi',
+                    data: salesData.pipeline.map(item => item.value),
+                    backgroundColor: salesData.pipeline.map((_, index) => `rgba(56, 189, 248, ${1 - index * 0.15})`),
+                    borderRadius: 12,
+                    barThickness: 24
+                }
+            ]
+        },
+        options: {
+            indexAxis: 'y',
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false }
+            },
+            scales: {
+                x: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.08)' }
+                },
+                y: {
+                    ticks: { color: colors.muted },
+                    grid: { display: false }
+                }
+            }
+        }
+    });
+
+    const productsBody = qs('#topProducts tbody');
+    if (productsBody) {
+        productsBody.innerHTML = salesData.topProducts
+            .map(product => `
+                <tr>
+                    <td>${product.name}</td>
+                    <td>${product.revenue.toLocaleString('tr-TR', { style: 'currency', currency: 'USD' })}</td>
+                    <td>
+                        <span class="metric-change ${product.growth < 0 ? 'negative' : ''}">
+                            <span class="badge">${product.growth < 0 ? 'Düşüş' : 'Artış'}</span>
+                            <span class="value">${product.growth}%</span>
+                        </span>
+                    </td>
+                    <td>${product.status}</td>
+                </tr>
+            `)
+            .join('');
+    }
+}
+
+function renderUsersPage() {
+    const activityCanvas = qs('#userActivityChart');
+    if (!activityCanvas) return;
+
+    new Chart(activityCanvas, {
+        type: 'line',
+        data: {
+            labels: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
+            datasets: [
+                {
+                    label: 'Günlük Aktif Kullanıcı',
+                    data: usersData.activity.dailyActive,
+                    borderColor: colors.primary,
+                    backgroundColor: `${colors.primary}33`,
+                    tension: 0.4,
+                    fill: true
+                },
+                {
+                    label: 'Yeni Kayıt',
+                    data: usersData.activity.newSignups,
+                    borderColor: colors.secondary,
+                    backgroundColor: `${colors.secondary}33`,
+                    tension: 0.4,
+                    fill: true
+                }
+            ]
+        },
+        options: {
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    labels: { color: '#e2e8f0' }
+                }
+            },
+            scales: {
+                x: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.08)' }
+                },
+                y: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.08)' }
+                }
+            }
+        }
+    });
+
+    const segmentsCanvas = qs('#segmentChart');
+    new Chart(segmentsCanvas, {
+        type: 'doughnut',
+        data: {
+            labels: usersData.segments.map(segment => segment.label),
+            datasets: [
+                {
+                    data: usersData.segments.map(segment => segment.value),
+                    backgroundColor: [
+                        `${colors.primary}cc`,
+                        `${colors.secondary}cc`,
+                        `${colors.tertiary}cc`,
+                        `${colors.primary}77`
+                    ],
+                    borderWidth: 0
+                }
+            ]
+        },
+        options: {
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    labels: { color: '#e2e8f0' }
+                }
+            }
+        }
+    });
+
+    const retentionBody = qs('#retentionTable tbody');
+    if (retentionBody) {
+        retentionBody.innerHTML = usersData.retention
+            .map(record => `
+                <tr>
+                    <td>${record.month}</td>
+                    <td>${record.rate}%</td>
+                    <td>
+                        <div class="progress">
+                            <div class="progress-bar" style="width:${record.rate}%"></div>
+                        </div>
+                    </td>
+                </tr>
+            `)
+            .join('');
+    }
+
+    const ticketBody = qs('#supportTickets tbody');
+    if (ticketBody) {
+        ticketBody.innerHTML = usersData.supportTickets
+            .map(ticket => `
+                <tr>
+                    <td>${ticket.id}</td>
+                    <td>${ticket.user}</td>
+                    <td>${ticket.priority}</td>
+                    <td>${ticket.topic}</td>
+                    <td>${ticket.status}</td>
+                    <td>${ticket.updatedAt}</td>
+                </tr>
+            `)
+            .join('');
+    }
+}
+
+function renderReportsPage() {
+    const kpiContainer = qs('#reportKpis');
+    if (!kpiContainer) return;
+
+    kpiContainer.innerHTML = reportsData.kpis
+        .map(
+            kpi => `
+            <div class="card">
+                <h3>${kpi.label}</h3>
+                <p class="metric-value">${kpi.value}</p>
+                <p class="metric-change ${kpi.change < 0 ? 'negative' : ''}">
+                    <span class="badge">${kpi.change < 0 ? 'Düşüş' : 'Artış'}</span>
+                    <span class="value">${kpi.change > 0 ? '+' : ''}${kpi.change}%</span>
+                </p>
+            </div>
+        `
+        )
+        .join('');
+
+    const quarterlyCanvas = qs('#quarterlyChart');
+    new Chart(quarterlyCanvas, {
+        type: 'bar',
+        data: {
+            labels: reportsData.quarterlyPerformance.labels,
+            datasets: [
+                {
+                    label: 'Gelir',
+                    data: reportsData.quarterlyPerformance.revenue,
+                    backgroundColor: `${colors.primary}aa`,
+                    borderRadius: 10
+                },
+                {
+                    label: 'Gider',
+                    data: reportsData.quarterlyPerformance.expenses,
+                    backgroundColor: `${colors.secondary}aa`,
+                    borderRadius: 10
+                }
+            ]
+        },
+        options: {
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    labels: { color: '#e2e8f0' }
+                }
+            },
+            scales: {
+                x: {
+                    ticks: { color: colors.muted },
+                    grid: { display: false }
+                },
+                y: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.1)' }
+                }
+            }
+        }
+    });
+
+    const forecastCanvas = qs('#forecastChart');
+    new Chart(forecastCanvas, {
+        type: 'line',
+        data: {
+            labels: reportsData.forecast.labels,
+            datasets: [
+                {
+                    label: 'Projeksiyon',
+                    data: reportsData.forecast.projection,
+                    borderColor: colors.primary,
+                    backgroundColor: `${colors.primary}33`,
+                    tension: 0.4,
+                    fill: true
+                },
+                {
+                    label: 'Hedef',
+                    data: reportsData.forecast.target,
+                    borderColor: colors.secondary,
+                    backgroundColor: `${colors.secondary}33`,
+                    tension: 0.4,
+                    fill: true
+                }
+            ]
+        },
+        options: {
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    labels: { color: '#e2e8f0' }
+                }
+            },
+            scales: {
+                x: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.08)' }
+                },
+                y: {
+                    ticks: { color: colors.muted },
+                    grid: { color: 'rgba(148, 163, 184, 0.08)' }
+                }
+            }
+        }
+    });
+}
+
+function decorateProgressBars() {
+    qsa('.progress').forEach(progress => {
+        if (!progress.querySelector('.progress-bar')) {
+            const value = Number(progress.dataset.value || 0);
+            const bar = document.createElement('div');
+            bar.className = 'progress-bar';
+            bar.style.width = `${value}%`;
+            progress.appendChild(bar);
+        }
+    });
+}
+
+function init() {
+    const pathname = window.location.pathname.split('/').pop() || 'index.html';
+    setActiveNav(pathname);
+    renderMetricCards();
+    decorateProgressBars();
+    renderDashboard();
+    renderSalesPage();
+    renderUsersPage();
+    renderReportsPage();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/site/assets/data.js
+++ b/site/assets/data.js
@@ -1,0 +1,89 @@
+export const dashboardMetrics = {
+    revenue: {
+        value: '$128,450',
+        change: 12.6,
+        trend: [8200, 9600, 10200, 11800, 12400, 13750, 14200, 15200, 15800, 16600, 17200, 18400]
+    },
+    orders: {
+        value: '1,482',
+        change: 4.1,
+        trend: [96, 102, 110, 108, 124, 130, 126, 142, 154, 166, 158, 172]
+    },
+    retention: {
+        value: '87%',
+        change: 2.4,
+        trend: [74, 76, 78, 79, 81, 82, 83, 84, 85, 86, 87, 88]
+    },
+    activeUsers: {
+        value: '12,985',
+        change: -1.8,
+        trend: [11240, 11600, 11950, 12110, 12400, 12890, 13200, 13150, 12980, 12860, 12910, 12985]
+    }
+};
+
+export const salesData = {
+    categories: ['Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran', 'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık'],
+    revenueByChannel: {
+        online: [8200, 8600, 9200, 9800, 11200, 11800, 12400, 13400, 14200, 15100, 15800, 16950],
+        retail: [6200, 6400, 6800, 7300, 7800, 8100, 8700, 9100, 9500, 9900, 10300, 10800]
+    },
+    topProducts: [
+        { name: 'AI Analytics Suite', revenue: 28400, growth: 18.4, status: 'Yükselişte' },
+        { name: 'Automation Toolkit', revenue: 22680, growth: 11.2, status: 'Stabil' },
+        { name: 'Predictive CRM', revenue: 19870, growth: -2.6, status: 'İyileştirme' },
+        { name: 'Insight Dashboard', revenue: 15440, growth: 8.3, status: 'Yükselişte' }
+    ],
+    pipeline: [
+        { stage: 'Potansiyel', value: 146 },
+        { stage: 'İlk Temas', value: 108 },
+        { stage: 'Demo', value: 78 },
+        { stage: 'Teklif', value: 44 },
+        { stage: 'Kapanan', value: 26 }
+    ]
+};
+
+export const usersData = {
+    activity: {
+        dailyActive: [420, 460, 510, 550, 580, 610, 640],
+        newSignups: [56, 68, 72, 80, 74, 86, 92]
+    },
+    segments: [
+        { label: 'Kurumsal', value: 34 },
+        { label: 'KOBİ', value: 41 },
+        { label: 'Startup', value: 18 },
+        { label: 'Bireysel', value: 7 }
+    ],
+    retention: [
+        { month: '1. Ay', rate: 92 },
+        { month: '2. Ay', rate: 88 },
+        { month: '3. Ay', rate: 84 },
+        { month: '4. Ay', rate: 81 },
+        { month: '5. Ay', rate: 79 },
+        { month: '6. Ay', rate: 76 }
+    ],
+    supportTickets: [
+        { id: '#9842', user: 'Elif Demir', priority: 'Yüksek', topic: 'Faturalandırma', status: 'Açık', updatedAt: '5 dk önce' },
+        { id: '#9834', user: 'Mert Yılmaz', priority: 'Orta', topic: 'Entegrasyon', status: 'Yanıtlandı', updatedAt: '20 dk önce' },
+        { id: '#9821', user: 'Eda Kaya', priority: 'Yüksek', topic: 'Performans', status: 'İşlemde', updatedAt: '42 dk önce' },
+        { id: '#9816', user: 'Burak Şen', priority: 'Düşük', topic: 'Eğitim', status: 'Kapandı', updatedAt: '1 saat önce' }
+    ]
+};
+
+export const reportsData = {
+    kpis: [
+        { label: 'Yıllık Büyüme', value: '36%', change: 5.4 },
+        { label: 'Net Gelir', value: '$864K', change: 3.8 },
+        { label: 'Dönüşüm Oranı', value: '4.2%', change: 0.6 },
+        { label: 'Müşteri Başına Gelir', value: '$256', change: 1.4 }
+    ],
+    quarterlyPerformance: {
+        labels: ['Q1', 'Q2', 'Q3', 'Q4'],
+        revenue: [210000, 238000, 264000, 298000],
+        expenses: [142000, 151000, 169000, 182000]
+    },
+    forecast: {
+        labels: ['Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran'],
+        projection: [72000, 74500, 77200, 80400, 83600, 86200],
+        target: [70000, 73000, 76000, 79000, 82000, 85000]
+    }
+};

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,0 +1,336 @@
+:root {
+    --bg-color: #0f172a;
+    --card-bg: #1e293b;
+    --accent: #38bdf8;
+    --accent-alt: #818cf8;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --success: #34d399;
+    --danger: #f87171;
+    --warning: #fbbf24;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 1) 0%, rgba(30, 41, 59, 1) 100%);
+    color: var(--text);
+    min-height: 100vh;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    min-height: 100vh;
+}
+
+.sidebar {
+    background-color: rgba(15, 23, 42, 0.95);
+    padding: 2rem 1.25rem;
+    box-shadow: 6px 0 24px rgba(8, 15, 30, 0.6);
+    position: sticky;
+    top: 0;
+    height: 100vh;
+}
+
+.sidebar h1 {
+    font-size: 1.5rem;
+    margin-bottom: 2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--accent);
+}
+
+.nav-links {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.nav-links a {
+    padding: 0.85rem 1rem;
+    border-radius: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--muted);
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.nav-links a.active,
+.nav-links a:hover {
+    background: linear-gradient(120deg, rgba(56, 189, 248, 0.15), rgba(129, 140, 248, 0.15));
+    color: var(--text);
+    transform: translateX(6px);
+}
+
+.nav-links a span.icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.75rem;
+    background: rgba(56, 189, 248, 0.1);
+    color: var(--accent);
+    font-size: 1.1rem;
+}
+
+main {
+    padding: 2.5rem 3rem;
+}
+
+header.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+header.page-header h2 {
+    margin: 0;
+    font-size: 2rem;
+    letter-spacing: 0.02em;
+}
+
+header.page-header .actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.button {
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), rgba(129, 140, 248, 0.3));
+    border: 1px solid rgba(56, 189, 248, 0.4);
+    color: var(--text);
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 30px rgba(56, 189, 248, 0.2);
+}
+
+.grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.grid.cols-3 {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.grid.cols-2 {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.grid.cols-4 {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.card {
+    background-color: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.1);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 20px 45px rgba(8, 15, 30, 0.25);
+    backdrop-filter: blur(12px);
+}
+
+.card ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.4rem;
+}
+
+.card ul li {
+    color: var(--muted);
+}
+
+.card h3 {
+    margin-top: 0;
+    font-size: 1rem;
+    color: var(--muted);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.card-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 1.25rem;
+}
+
+.metric-value {
+    font-size: 2rem;
+    font-weight: 700;
+    margin: 0.5rem 0;
+}
+
+.metric-change {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--success);
+    font-size: 0.95rem;
+}
+
+.metric-change.negative {
+    color: var(--danger);
+}
+
+.metric-change span.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(52, 211, 153, 0.15);
+}
+
+.metric-change.negative span.badge {
+    background: rgba(248, 113, 113, 0.15);
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1.5rem;
+}
+
+.table th,
+.table td {
+    padding: 0.85rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.table th {
+    color: var(--muted);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.table tr:hover {
+    background: rgba(56, 189, 248, 0.08);
+}
+
+.muted {
+    color: var(--muted);
+    margin: 0.2rem 0 0;
+}
+
+.status-badge {
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.status-badge.success {
+    background: rgba(52, 211, 153, 0.15);
+    color: var(--success);
+}
+
+.status-badge.warning {
+    background: rgba(251, 191, 36, 0.15);
+    color: var(--warning);
+}
+
+.status-badge.danger {
+    background: rgba(248, 113, 113, 0.15);
+    color: var(--danger);
+}
+
+.chart-container {
+    position: relative;
+    width: 100%;
+    height: 320px;
+}
+
+@media (max-width: 960px) {
+    .layout {
+        grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+        position: static;
+        height: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    main {
+        padding: 1.5rem;
+    }
+}
+
+@media (max-width: 640px) {
+    header.page-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .button {
+        width: 100%;
+        text-align: center;
+    }
+}
+.progress {
+    position: relative;
+    width: 100%;
+    height: 0.6rem;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.15);
+    overflow: hidden;
+}
+
+.progress .progress-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: linear-gradient(90deg, rgba(56, 189, 248, 0.8), rgba(129, 140, 248, 0.9));
+}
+
+.table-responsive {
+    overflow-x: auto;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.badge::before {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.8;
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nova Analytics | Yönetim Paneli</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/styles.css">
+</head>
+<body>
+    <div class="layout">
+        <aside class="sidebar">
+            <h1><span class="icon">⚡</span>Nova Analytics</h1>
+            <nav class="nav-links">
+                <a href="index.html"><span class="icon">📊</span>Dashboard</a>
+                <a href="sales.html"><span class="icon">💰</span>Satışlar</a>
+                <a href="users.html"><span class="icon">🧑‍💼</span>Kullanıcılar</a>
+                <a href="reports.html"><span class="icon">📈</span>Raporlar</a>
+            </nav>
+        </aside>
+        <main>
+            <header class="page-header">
+                <div>
+                    <h2>Genel Bakış</h2>
+                    <p>Ürün performansı, satış ve müşteri davranışlarına dair son 30 günün özeti.</p>
+                </div>
+                <div class="actions">
+                    <button class="button">Rapor Oluştur</button>
+                    <button class="button">Canlı Paylaş</button>
+                </div>
+            </header>
+
+            <section class="grid cols-3">
+                <article class="card" data-metric="revenue">
+                    <h3>Aylık Gelir</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+                <article class="card" data-metric="orders">
+                    <h3>Yeni Sipariş</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+                <article class="card" data-metric="retention">
+                    <h3>Müşteri Tutma</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+            </section>
+
+            <section class="grid cols-2" style="margin-top: 2rem;">
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Aylık Gelir Trendleri</h3>
+                        <p class="muted">Online ve mağaza kanallarının performans karşılaştırması.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="revenueChart"></canvas>
+                    </div>
+                </article>
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Kaynak Bazlı Dönüşümler</h3>
+                        <p class="muted">Organik, reklam, referans ve etkinlik kampanyaları.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="conversionChart"></canvas>
+                    </div>
+                </article>
+            </section>
+
+            <section class="card" style="margin-top: 2rem;">
+                <div class="card-header">
+                    <h3>En Aktif Müşteriler</h3>
+                    <p class="muted">MRR (aylık tekrar eden gelir) ve durumlarına göre sıralı liste.</p>
+                </div>
+                <div class="table-responsive">
+                    <table class="table" id="topCustomers">
+                        <thead>
+                            <tr>
+                                <th>Müşteri</th>
+                                <th>Paket</th>
+                                <th>MRR</th>
+                                <th>Son Aktivite</th>
+                                <th>Durum</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+    <script type="module" src="./assets/app.js"></script>
+</body>
+</html>

--- a/site/reports.html
+++ b/site/reports.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nova Analytics | Yönetim Raporları</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/styles.css">
+</head>
+<body>
+    <div class="layout">
+        <aside class="sidebar">
+            <h1><span class="icon">⚡</span>Nova Analytics</h1>
+            <nav class="nav-links">
+                <a href="index.html"><span class="icon">📊</span>Dashboard</a>
+                <a href="sales.html"><span class="icon">💰</span>Satışlar</a>
+                <a href="users.html"><span class="icon">🧑‍💼</span>Kullanıcılar</a>
+                <a href="reports.html"><span class="icon">📈</span>Raporlar</a>
+            </nav>
+        </aside>
+        <main>
+            <header class="page-header">
+                <div>
+                    <h2>Stratejik Raporlar</h2>
+                    <p>KPI performansı, çeyreklik sonuçlar ve gelir projeksiyonlarına ilişkin özet.</p>
+                </div>
+                <div class="actions">
+                    <button class="button">PDF'e Aktar</button>
+                    <button class="button">Paydaşlarla Paylaş</button>
+                </div>
+            </header>
+
+            <section class="grid cols-4" id="reportKpis"></section>
+
+            <section class="grid cols-2" style="margin-top: 2rem;">
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Çeyreklik Finansal Sonuçlar</h3>
+                        <p class="muted">Gelir ve gider trendlerinin çeyreklik karşılaştırması.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="quarterlyChart"></canvas>
+                    </div>
+                </article>
+                <article class="card">
+                    <div class="card-header">
+                        <h3>6 Aylık Gelir Tahmini</h3>
+                        <p class="muted">Gerçekleşme projeksiyonu ve hedef kıyaslaması.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="forecastChart"></canvas>
+                    </div>
+                </article>
+            </section>
+
+            <section class="card" style="margin-top: 2rem;">
+                <div class="card-header">
+                    <h3>Yönetici Özet Notları</h3>
+                    <p class="muted">Bu dönem için dikkat edilmesi gereken maddeler ve aksiyon önerileri.</p>
+                </div>
+                <div class="grid" style="gap: 1rem;">
+                    <div class="card" style="background: rgba(56, 189, 248, 0.08); border: 1px solid rgba(56, 189, 248, 0.2);">
+                        <h3>Büyüme Odakları</h3>
+                        <ul>
+                            <li>APAC bölgesindeki enterprise fırsatların hızlandırılması.</li>
+                            <li>Ürün içi yükseltme kampanyası ile LTV'nin artırılması.</li>
+                            <li>Ortak pazarlama planı ile referans kanalının güçlendirilmesi.</li>
+                        </ul>
+                    </div>
+                    <div class="card" style="background: rgba(129, 140, 248, 0.08); border: 1px solid rgba(129, 140, 248, 0.2);">
+                        <h3>Risk ve Önlemler</h3>
+                        <ul>
+                            <li>Kur dalgalanmalarına karşı fiyatlandırma revizyonu.</li>
+                            <li>İşletme maliyetlerini %4 azaltacak otomasyon planı.</li>
+                            <li>İptal eden müşteriler için yeniden kazanım programı.</li>
+                        </ul>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+    <script type="module" src="./assets/app.js"></script>
+</body>
+</html>

--- a/site/sales.html
+++ b/site/sales.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nova Analytics | Satış Analizi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/styles.css">
+</head>
+<body>
+    <div class="layout">
+        <aside class="sidebar">
+            <h1><span class="icon">⚡</span>Nova Analytics</h1>
+            <nav class="nav-links">
+                <a href="index.html"><span class="icon">📊</span>Dashboard</a>
+                <a href="sales.html"><span class="icon">💰</span>Satışlar</a>
+                <a href="users.html"><span class="icon">🧑‍💼</span>Kullanıcılar</a>
+                <a href="reports.html"><span class="icon">📈</span>Raporlar</a>
+            </nav>
+        </aside>
+        <main>
+            <header class="page-header">
+                <div>
+                    <h2>Satış Performansı</h2>
+                    <p>Kanal bazlı gelirler, pipeline görünümü ve ürün katkıları.</p>
+                </div>
+                <div class="actions">
+                    <button class="button">CSV Aktar</button>
+                    <button class="button">Tahminleri Güncelle</button>
+                </div>
+            </header>
+
+            <section class="grid cols-3">
+                <article class="card" data-metric="revenue">
+                    <h3>Toplam Gelir</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+                <article class="card" data-metric="orders">
+                    <h3>Satış Adedi</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+                <article class="card" data-metric="activeUsers">
+                    <h3>Aktif Abone</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+            </section>
+
+            <section class="grid cols-2" style="margin-top: 2rem;">
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Kanal Bazlı Gelir Dağılımı</h3>
+                        <p class="muted">E-ticaret ve fiziksel mağaza kanallarındaki aylık gelir trendi.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="channelBreakdown"></canvas>
+                    </div>
+                </article>
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Satış Hunisi</h3>
+                        <p class="muted">Farklı aşamalardaki fırsat sayıları ve dönüşüm gücü.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="pipelineChart"></canvas>
+                    </div>
+                </article>
+            </section>
+
+            <section class="card" style="margin-top: 2rem;">
+                <div class="card-header">
+                    <h3>En Çok Satan Ürünler</h3>
+                    <p class="muted">Gelir katkısı, büyüme oranı ve durum özetleri.</p>
+                </div>
+                <div class="table-responsive">
+                    <table class="table" id="topProducts">
+                        <thead>
+                            <tr>
+                                <th>Ürün</th>
+                                <th>Gelir</th>
+                                <th>Büyüme</th>
+                                <th>Durum</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+    <script type="module" src="./assets/app.js"></script>
+</body>
+</html>

--- a/site/users.html
+++ b/site/users.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nova Analytics | Kullanıcı Analizi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="./assets/styles.css">
+</head>
+<body>
+    <div class="layout">
+        <aside class="sidebar">
+            <h1><span class="icon">⚡</span>Nova Analytics</h1>
+            <nav class="nav-links">
+                <a href="index.html"><span class="icon">📊</span>Dashboard</a>
+                <a href="sales.html"><span class="icon">💰</span>Satışlar</a>
+                <a href="users.html"><span class="icon">🧑‍💼</span>Kullanıcılar</a>
+                <a href="reports.html"><span class="icon">📈</span>Raporlar</a>
+            </nav>
+        </aside>
+        <main>
+            <header class="page-header">
+                <div>
+                    <h2>Kullanıcı Davranışları</h2>
+                    <p>Aktivite trendleri, segmentler ve destek taleplerine hızlı bakış.</p>
+                </div>
+                <div class="actions">
+                    <button class="button">Segment Oluştur</button>
+                    <button class="button">Kitleyi Karşılaştır</button>
+                </div>
+            </header>
+
+            <section class="grid cols-3">
+                <article class="card" data-metric="activeUsers">
+                    <h3>Aktif Kullanıcı</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+                <article class="card" data-metric="retention">
+                    <h3>Tutma Oranı</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+                <article class="card" data-metric="orders">
+                    <h3>Yeni Kayıt</h3>
+                    <p class="metric-value"></p>
+                    <p class="metric-change">
+                        <span class="badge"></span>
+                        <span class="value"></span>
+                    </p>
+                    <div class="chart-container" style="height: 120px;">
+                        <canvas></canvas>
+                    </div>
+                </article>
+            </section>
+
+            <section class="grid cols-2" style="margin-top: 2rem;">
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Haftalık Aktivite</h3>
+                        <p class="muted">Günlük aktif kullanıcı ve yeni kayıt trendleri.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="userActivityChart"></canvas>
+                    </div>
+                </article>
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Kitle Segmentleri</h3>
+                        <p class="muted">Kurumsal, KOBİ, Startup ve bireysel kullanıcı dağılımı.</p>
+                    </div>
+                    <div class="chart-container">
+                        <canvas id="segmentChart"></canvas>
+                    </div>
+                </article>
+            </section>
+
+            <section class="grid cols-2" style="margin-top: 2rem;">
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Cohort Retention</h3>
+                        <p class="muted">İlk 6 ay içerisindeki müşteri tutma oranları.</p>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table" id="retentionTable">
+                            <thead>
+                                <tr>
+                                    <th>Dönem</th>
+                                    <th>Oran</th>
+                                    <th>Trend</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </article>
+                <article class="card">
+                    <div class="card-header">
+                        <h3>Destek Talepleri</h3>
+                        <p class="muted">Güncel taleplerin öncelik, konu ve durum özetleri.</p>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table" id="supportTickets">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Kullanıcı</th>
+                                    <th>Öncelik</th>
+                                    <th>Konu</th>
+                                    <th>Durum</th>
+                                    <th>Güncelleme</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </article>
+            </section>
+        </main>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+    <script type="module" src="./assets/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a four-page Nova Analytics dashboard experience with shared navigation and layout
- populate dashboards with demo sales and user analytics rendered through Chart.js visualizations
- introduce shared styling and data modules for a cohesive, glassmorphism-inspired presentation

## Testing
- Manual visual check of index.html in browser

------
https://chatgpt.com/codex/tasks/task_e_68e6d37f84408322946dcd55faa2ab96