### PR TITLE
Add desktop Sahibinden scraper with GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,61 @@
-# Grok Free API
-This is unoffical free Grok OpenAI type API.  
-**This is unstable and may against grok TOS, use at your own risk!!**
-## setup
-Add your cookie in `main.py` first  
+# Grok Free API & Sahibinden Scraper Toolkit
+
+This repository now contains two separate utilities:
+
+1. **FastAPI proxy** (existing `main.py`) – demonstrates how to proxy requests to xAI's Grok API.
+2. **Sahibinden.com real-estate scraper GUI** – a Tkinter-based desktop client that can collect
+   property listings from sahibinden.com, filter them, and export the results to Excel/CSV.
+
+## Sahibinden Scraper
+
+> ⚠️ **Yasal Uyarı:** Sahibinden.com'dan veri çekerken mutlaka kullanım şartlarını ve ilgili
+> mevzuatı inceleyin. `robots.txt` dosyasına uyun, aşırı istek göndermeyin ve kişisel verilerin
+> korunmasına dikkat edin. Bu proje yalnızca eğitim amaçlıdır; sorumluluk kullanıcıya aittir.
+
+### Özellikler
+
+- Konum, fiyat, oda sayısı, metrekare vb. filtrelerle ilan arama.
+- Sayfa bazlı veri çekme ve maksimum ilan limiti.
+- Acil veya istenmeyen anahtar kelimeleri hariç tutma.
+- BeautifulSoup tabanlı HTML ayrıştırma, isteğe bağlı proxy/headless tarayıcı desteği için hazır yapı.
+- Pandas DataFrame olarak veri işleme, duplikasyonları filtreleme.
+- Excel (`.xlsx`) veya CSV olarak dışa aktarma.
+- Tkinter arayüzü (filtre girişleri, arama butonu, ilerleme çubuğu, sonuç tablosu).
+- Günlük (log) dosyası oluşturma ve site yapısı değiştiğinde anlamlı hatalar verme.
+
+### Kurulum
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows için .venv\\Scripts\\activate
+pip install -r requirements.txt
 ```
-uv venv
-uv pip install -r requirements.txt
-git clone https://github.com/mem0ai/grok3-api.git
-cd ./grok3-api
-uv pip install .
-cd ..
-main.py
+
+Selenium ile headless tarayıcı kullanmak isterseniz sisteminizde uygun bir WebDriver (örneğin
+`chromedriver`) bulunmalıdır.
+
+### Kullanım
+
+```bash
+python -m sahibinden_scraper.gui
 ```
-You can access it at `127.0.0.1:8046/v1`  
+
+1. Filtreleri doldurun ve "İlanları Ara" butonuna basın.
+2. İsterseniz çıktı klasörünü değiştirin ve maksimum ilan sayısını ayarlayın.
+3. Liste dolduktan sonra "Excel'e Aktar" ile verileri `exports/` klasörüne kaydedin.
+
+Log dosyası varsayılan olarak `logs/scraper.log` konumunda tutulur.
+
+## Mevcut FastAPI Uygulaması
+
+```
+uvicorn main:app --reload
+```
+
+Bu uygulama, Grok API isteği yapabilmek için gerekli çerezleri (`cookies`) `main.py` dosyasında
+belirtmenizi gerektirir.
+
+## Lisans
+
+Bu projede kullanılan tüm üçüncü parti kütüphaneler açık kaynaklıdır. Kodlar eğitim amaçlı olup,
+her türlü kullanım sorumluluğu kullanıcıya aittir.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 fastapi
 uvicorn
+requests
+beautifulsoup4
+pandas
+openpyxl
+selenium

--- a/sahibinden_scraper/__init__.py
+++ b/sahibinden_scraper/__init__.py
@@ -1,0 +1,15 @@
+"""Sahibinden.com scraping toolkit."""
+
+from .config import ScraperConfig, SearchFilters, ProxySettings
+from .scraper import Listing, SahibindenScraper, ScraperError
+from .export import export_dataframe
+
+__all__ = [
+    "ScraperConfig",
+    "SearchFilters",
+    "ProxySettings",
+    "Listing",
+    "SahibindenScraper",
+    "ScraperError",
+    "export_dataframe",
+]

--- a/sahibinden_scraper/config.py
+++ b/sahibinden_scraper/config.py
@@ -1,0 +1,108 @@
+"""Configuration utilities for the Sahibinden scraper."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+@dataclass
+class ProxySettings:
+    """Container describing proxy options for HTTP requests."""
+
+    http: Optional[str] = None
+    https: Optional[str] = None
+
+    def as_requests_proxies(self) -> Dict[str, str]:
+        """Return a dictionary that can be consumed by :mod:`requests`.
+
+        Returns an empty dictionary when no proxies are configured.
+        """
+
+        proxies: Dict[str, str] = {}
+        if self.http:
+            proxies["http"] = self.http
+        if self.https:
+            proxies["https"] = self.https
+        return proxies
+
+
+@dataclass
+class ScraperConfig:
+    """Runtime settings for :class:`~sahibinden_scraper.scraper.SahibindenScraper`."""
+
+    base_url: str = "https://www.sahibinden.com"
+    listing_path: str = "emlak"
+    rate_limit_seconds: Tuple[float, float] = (2.0, 5.0)
+    max_listings: int = 100
+    user_agent: str = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/123.0 Safari/537.36"
+    )
+    output_directory: Path = field(default_factory=lambda: Path.cwd() / "exports")
+    log_file: Path = field(default_factory=lambda: Path.cwd() / "logs" / "scraper.log")
+    verify_robots: bool = True
+    use_selenium: bool = False
+
+
+@dataclass
+class SearchFilters:
+    """Structured representation of supported search filters."""
+
+    city: str = ""
+    district: str = ""
+    listing_type: str = "satilik"  # satilik, kiralik, vb.
+    property_type: str = ""  # apartment, villa, land, etc.
+    price_min: Optional[int] = None
+    price_max: Optional[int] = None
+    room_count: Optional[str] = None
+    area_min: Optional[int] = None
+    area_max: Optional[int] = None
+    exclude_keywords: Iterable[str] = field(default_factory=tuple)
+    exclude_urgent: bool = False
+    include_photos: bool = False
+
+    def to_query_params(self) -> Dict[str, str]:
+        """Translate search filters to sahibinden.com query parameters.
+
+        The public site uses query parameters such as ``pagingOffset`` and
+        ``pagingSize``. Since sahibinden.com frequently changes these parameters,
+        the method keeps the mapping in a single place so the scraper can be
+        updated quickly when required.
+        """
+
+        params: Dict[str, str] = {}
+        if self.city:
+            params["city"] = self.city
+        if self.district:
+            params["district"] = self.district
+        if self.listing_type:
+            params["listingType"] = self.listing_type
+        if self.property_type:
+            params["propertyType"] = self.property_type
+        if self.price_min is not None:
+            params["price_min"] = str(self.price_min)
+        if self.price_max is not None:
+            params["price_max"] = str(self.price_max)
+        if self.room_count:
+            params["roomCount"] = self.room_count
+        if self.area_min is not None:
+            params["area_min"] = str(self.area_min)
+        if self.area_max is not None:
+            params["area_max"] = str(self.area_max)
+        if self.include_photos:
+            params["photo"] = "1"
+        return params
+
+    def excluded_terms(self) -> List[str]:
+        """Return the list of keywords that must not appear in a listing."""
+
+        terms: List[str] = []
+        if self.exclude_urgent:
+            terms.append("acil")
+        terms.extend([term.lower() for term in self.exclude_keywords])
+        return terms
+
+
+__all__ = ["ProxySettings", "ScraperConfig", "SearchFilters"]

--- a/sahibinden_scraper/export.py
+++ b/sahibinden_scraper/export.py
@@ -1,0 +1,37 @@
+"""Utility helpers for exporting listing information."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def export_dataframe(df: pd.DataFrame, destination: Path, to_excel: bool = True) -> Path:
+    """Write the dataframe to ``destination``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame that should be exported. Duplicate rows are removed before
+        writing to disk.
+    destination:
+        Directory or full path where the file should be created.
+    to_excel:
+        When ``True`` (default) the dataframe is exported as ``.xlsx`` using
+        :mod:`openpyxl`. Otherwise a CSV file is produced.
+    """
+
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    sanitized = df.drop_duplicates()
+    if to_excel:
+        if destination.suffix.lower() != ".xlsx":
+            destination = destination.with_suffix(".xlsx")
+        sanitized.to_excel(destination, index=False)
+    else:
+        if destination.suffix.lower() != ".csv":
+            destination = destination.with_suffix(".csv")
+        sanitized.to_csv(destination, index=False)
+
+    return destination

--- a/sahibinden_scraper/gui.py
+++ b/sahibinden_scraper/gui.py
@@ -1,0 +1,314 @@
+"""Tkinter based GUI for the Sahibinden scraper."""
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from tkinter import BooleanVar, IntVar, StringVar, Tk, filedialog, messagebox
+from tkinter import ttk
+from typing import Optional
+
+import pandas as pd
+
+from .config import ProxySettings, ScraperConfig, SearchFilters
+from .scraper import SahibindenScraper, ScraperError
+from .utils import setup_logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ScraperGUI:
+    """Encapsulates the Tkinter widgets and interactions."""
+
+    def __init__(self, root: Tk) -> None:
+        self.root = root
+        self.root.title("Sahibinden.com Emlak Çekici")
+        self.root.geometry("950x600")
+
+        self.config = ScraperConfig()
+        setup_logging(self.config.log_file)
+
+        self.scraper = SahibindenScraper(self.config)
+        self.listings_df: Optional[pd.DataFrame] = None
+
+        self._create_variables()
+        self._build_layout()
+
+    # ------------------------------------------------------------------
+    # UI setup
+    # ------------------------------------------------------------------
+    def _create_variables(self) -> None:
+        self.city = StringVar()
+        self.district = StringVar()
+        self.listing_type = StringVar(value="satilik")
+        self.property_type = StringVar()
+        self.price_min = StringVar()
+        self.price_max = StringVar()
+        self.room_count = StringVar()
+        self.area_min = StringVar()
+        self.area_max = StringVar()
+        self.exclude_keywords = StringVar()
+        self.exclude_urgent = BooleanVar(value=False)
+        self.include_photos = BooleanVar(value=False)
+        self.max_listings = IntVar(value=self.config.max_listings)
+        self.output_dir = StringVar(value=str(self.config.output_directory))
+        self.http_proxy = StringVar(value=self.scraper.proxies.http or "")
+        self.https_proxy = StringVar(value=self.scraper.proxies.https or "")
+        self.use_selenium = BooleanVar(value=self.config.use_selenium)
+
+    def _build_layout(self) -> None:
+        main_frame = ttk.Frame(self.root, padding=10)
+        main_frame.pack(fill="both", expand=True)
+
+        filters_frame = ttk.LabelFrame(main_frame, text="Filtreler", padding=10)
+        filters_frame.pack(fill="x", expand=False)
+
+        self._add_entry(filters_frame, "Şehir", self.city, 0, 0)
+        self._add_entry(filters_frame, "İlçe", self.district, 0, 1)
+
+        ttk.Label(filters_frame, text="İlan Tipi").grid(row=1, column=0, sticky="w", pady=5)
+        ttk.Combobox(
+            filters_frame,
+            textvariable=self.listing_type,
+            values=("satilik", "kiralik"),
+            state="readonly",
+            width=22,
+        ).grid(row=1, column=1, sticky="ew")
+
+        ttk.Label(filters_frame, text="Emlak Türü").grid(row=1, column=2, sticky="w")
+        ttk.Combobox(
+            filters_frame,
+            textvariable=self.property_type,
+            values=("daire", "villa", "arsa", "is yeri", ""),
+            width=22,
+        ).grid(row=1, column=3, sticky="ew")
+
+        self._add_entry(filters_frame, "Min Fiyat", self.price_min, 2, 0)
+        self._add_entry(filters_frame, "Max Fiyat", self.price_max, 2, 1)
+        self._add_entry(filters_frame, "Oda Sayısı", self.room_count, 2, 2)
+        self._add_entry(filters_frame, "Min m²", self.area_min, 2, 3)
+        self._add_entry(filters_frame, "Max m²", self.area_max, 3, 0)
+
+        ttk.Checkbutton(
+            filters_frame,
+            text="Acil ilanları hariç tut",
+            variable=self.exclude_urgent,
+        ).grid(row=3, column=1, sticky="w")
+
+        ttk.Checkbutton(
+            filters_frame,
+            text="Sadece fotoğraflı ilanlar",
+            variable=self.include_photos,
+        ).grid(row=3, column=2, sticky="w")
+
+        self._add_entry(filters_frame, "Hariç tutulacak kelimeler", self.exclude_keywords, 4, 0, columnspan=4)
+
+        settings_frame = ttk.LabelFrame(main_frame, text="Ayarlar", padding=10)
+        settings_frame.pack(fill="x", expand=False, pady=(10, 0))
+        settings_frame.columnconfigure((1, 3), weight=1)
+
+        self._add_entry(
+            settings_frame,
+            "İlan limiti",
+            self.max_listings,
+            0,
+            0,
+        )
+        ttk.Button(settings_frame, text="Çıktı klasörü seç", command=self._choose_directory).grid(
+            row=0, column=1, padx=5
+        )
+        ttk.Label(settings_frame, textvariable=self.output_dir).grid(row=0, column=2, sticky="w")
+
+        ttk.Label(settings_frame, text="HTTP Proxy").grid(row=1, column=0, sticky="w", pady=5)
+        ttk.Entry(settings_frame, textvariable=self.http_proxy, width=30).grid(
+            row=1, column=1, sticky="ew", padx=5
+        )
+        ttk.Label(settings_frame, text="HTTPS Proxy").grid(row=1, column=2, sticky="w", pady=5)
+        ttk.Entry(settings_frame, textvariable=self.https_proxy, width=30).grid(
+            row=1, column=3, sticky="ew", padx=5
+        )
+
+        ttk.Checkbutton(
+            settings_frame,
+            text="Headless Selenium kullan",
+            variable=self.use_selenium,
+        ).grid(row=2, column=0, columnspan=2, sticky="w", pady=5)
+
+        controls_frame = ttk.Frame(main_frame, padding=(0, 10))
+        controls_frame.pack(fill="x", expand=False)
+
+        ttk.Button(controls_frame, text="İlanları Ara", command=self._start_scraping).pack(
+            side="left", padx=5
+        )
+        ttk.Button(controls_frame, text="Excel'e Aktar", command=self._export_results).pack(
+            side="left", padx=5
+        )
+
+        self.progress = ttk.Progressbar(controls_frame, mode="determinate")
+        self.progress.pack(fill="x", expand=True, padx=5)
+
+        self.status_label = ttk.Label(controls_frame, text="Hazır")
+        self.status_label.pack(side="left", padx=5)
+
+        columns = (
+            "listing_id",
+            "title",
+            "price",
+            "location",
+            "area",
+            "room_count",
+            "publish_date",
+            "seller",
+        )
+        self.tree = ttk.Treeview(main_frame, columns=columns, show="headings")
+        for col in columns:
+            self.tree.heading(col, text=col.replace("_", " ").title())
+            self.tree.column(col, width=120 if col != "title" else 260)
+        self.tree.pack(fill="both", expand=True)
+
+    def _add_entry(
+        self,
+        parent: ttk.Frame,
+        label: str,
+        variable,
+        row: int,
+        column: int,
+        columnspan: int = 1,
+    ) -> None:
+        ttk.Label(parent, text=label).grid(row=row, column=column, sticky="w", pady=5)
+        entry = ttk.Entry(parent, textvariable=variable, width=22)
+        entry.grid(row=row, column=column + 1, sticky="ew", padx=5, pady=5, columnspan=columnspan)
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    def _choose_directory(self) -> None:
+        directory = filedialog.askdirectory()
+        if directory:
+            self.output_dir.set(directory)
+            self.scraper.config.output_directory = Path(directory)
+
+    def _start_scraping(self) -> None:
+        try:
+            limit = int(self.max_listings.get())
+            self.config.max_listings = limit
+        except ValueError:
+            messagebox.showerror("Hata", "İlan limiti sayısal olmalıdır")
+            return
+
+        self.progress.configure(maximum=self.config.max_listings, value=0)
+        self.status_label.config(text="İlanlar çekiliyor...")
+
+        self.scraper.config.use_selenium = self.use_selenium.get()
+        self.scraper.proxies = ProxySettings(
+            http=self.http_proxy.get() or None,
+            https=self.https_proxy.get() or None,
+        )
+
+        thread = threading.Thread(target=self._scrape_in_background, daemon=True)
+        thread.start()
+
+    def _scrape_in_background(self) -> None:
+        try:
+            filters = self._collect_filters()
+            df = self.scraper.fetch_listings(filters, progress_callback=self._update_progress)
+        except ScraperError as exc:
+            LOGGER.exception("Scraper error")
+            self._update_status(f"Hata: {exc}")
+            self._show_error(str(exc))
+            return
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.exception("Beklenmeyen hata")
+            self._update_status("Beklenmeyen bir hata oluştu")
+            self._show_error(str(exc))
+            return
+
+        self.root.after(0, lambda: self._handle_results(df))
+
+    def _collect_filters(self) -> SearchFilters:
+        exclude = [term.strip() for term in self.exclude_keywords.get().split(",") if term.strip()]
+        filters = SearchFilters(
+            city=self.city.get(),
+            district=self.district.get(),
+            listing_type=self.listing_type.get(),
+            property_type=self.property_type.get(),
+            price_min=self._safe_int(self.price_min.get()),
+            price_max=self._safe_int(self.price_max.get()),
+            room_count=self.room_count.get() or None,
+            area_min=self._safe_int(self.area_min.get()),
+            area_max=self._safe_int(self.area_max.get()),
+            exclude_keywords=exclude,
+            exclude_urgent=self.exclude_urgent.get(),
+            include_photos=self.include_photos.get(),
+        )
+        return filters
+
+    def _update_progress(self, current: int, total: Optional[int]) -> None:
+        self.root.after(0, lambda: self._update_progress_ui(current, total))
+
+    def _update_progress_ui(self, current: int, total: Optional[int]) -> None:
+        self.progress.configure(value=current)
+        if total:
+            self.progress.configure(maximum=total)
+        self.status_label.config(text=f"{current}/{total or '?'} ilan")
+
+    def _populate_tree(self, df: pd.DataFrame) -> None:
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        if df.empty:
+            return
+        for _, row in df.iterrows():
+            values = (
+                row.get("listing_id", ""),
+                row.get("title", ""),
+                row.get("price", ""),
+                row.get("location", ""),
+                row.get("area", ""),
+                row.get("room_count", ""),
+                row.get("publish_date", ""),
+                row.get("seller", ""),
+            )
+            self.tree.insert("", "end", values=values)
+
+    def _export_results(self) -> None:
+        if self.listings_df is None or self.listings_df.empty:
+            self._show_info("Önce ilanları arayın")
+            return
+        output_dir = Path(self.output_dir.get())
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / "sahibinden_listings.xlsx"
+        path = self.scraper.export_listings(self.listings_df, str(output_file), to_excel=True)
+        self._show_info(f"Dosya kaydedildi: {path}")
+
+    def _safe_int(self, value: str) -> Optional[int]:
+        try:
+            return int(value) if value else None
+        except ValueError:
+            return None
+
+    def _update_status(self, message: str) -> None:
+        self.root.after(0, lambda: self.status_label.config(text=message))
+
+    def _handle_results(self, df: pd.DataFrame) -> None:
+        self.listings_df = df
+        self._populate_tree(df)
+        self.status_label.config(text=f"{len(df)} ilan bulundu")
+
+    def _show_error(self, message: str) -> None:
+        self.root.after(0, lambda: messagebox.showerror("Hata", message))
+
+    def _show_info(self, message: str) -> None:
+        self.root.after(0, lambda: messagebox.showinfo("Bilgi", message))
+
+
+def launch_gui() -> None:
+    root = Tk()
+    app = ScraperGUI(root)
+    root.mainloop()
+
+
+__all__ = ["ScraperGUI", "launch_gui"]
+
+
+if __name__ == "__main__":
+    launch_gui()

--- a/sahibinden_scraper/scraper.py
+++ b/sahibinden_scraper/scraper.py
@@ -1,0 +1,300 @@
+"""Core scraping logic for Sahibinden.com listings."""
+from __future__ import annotations
+
+import logging
+import random
+import time
+import urllib.parse
+import urllib.robotparser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+try:  # Optional Selenium support
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options as ChromeOptions
+except ImportError:  # pragma: no cover - selenium is optional at runtime
+    webdriver = None
+    ChromeOptions = None
+
+from .config import ProxySettings, ScraperConfig, SearchFilters
+from .export import export_dataframe
+from .utils import ProgressCallback, any_term_in_text
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ScraperError(RuntimeError):
+    """Raised when scraping fails in a recoverable manner."""
+
+
+@dataclass
+class Listing:
+    """Data model representing a Sahibinden listing."""
+
+    listing_id: str
+    title: str
+    price: str
+    location: str
+    area: Optional[str]
+    room_count: Optional[str]
+    url: str
+    publish_date: Optional[str]
+    seller: Optional[str]
+    photo_url: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "listing_id": self.listing_id,
+            "title": self.title,
+            "price": self.price,
+            "location": self.location,
+            "area": self.area,
+            "room_count": self.room_count,
+            "url": self.url,
+            "publish_date": self.publish_date,
+            "seller": self.seller,
+            "photo_url": self.photo_url,
+        }
+
+
+class SahibindenScraper:
+    """High level interface that fetches and parses listings."""
+
+    def __init__(
+        self,
+        config: Optional[ScraperConfig] = None,
+        proxies: Optional[ProxySettings] = None,
+    ) -> None:
+        self.config = config or ScraperConfig()
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": self.config.user_agent})
+        self.proxies = proxies or ProxySettings()
+        self._robots: Optional[urllib.robotparser.RobotFileParser] = None
+        self._driver: Optional["webdriver.Chrome"] = None
+        self.config.output_directory.mkdir(parents=True, exist_ok=True)
+        self.config.log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    def __del__(self) -> None:  # pragma: no cover - best effort cleanup
+        try:
+            if self._driver:
+                self._driver.quit()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def fetch_listings(
+        self,
+        filters: SearchFilters,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> pd.DataFrame:
+        """Fetch listings matching ``filters`` and return them as a DataFrame."""
+
+        listings: List[Listing] = []
+        fetched = 0
+        page = 1
+        max_listings = self.config.max_listings
+
+        LOGGER.info("Starting scrape with filters: %s", filters)
+        while fetched < max_listings:
+            batch = self._fetch_page(filters, page)
+            if not batch:
+                LOGGER.info("No listings returned for page %s; stopping.", page)
+                break
+
+            for listing in batch:
+                if self._should_skip_listing(listing, filters.excluded_terms()):
+                    continue
+                listings.append(listing)
+                fetched += 1
+                if progress_callback:
+                    progress_callback(fetched, max_listings)
+                if fetched >= max_listings:
+                    LOGGER.info("Reached max listings limit (%s).", max_listings)
+                    break
+
+            page += 1
+            self._apply_rate_limit()
+
+        LOGGER.info("Fetched %s listings in total.", len(listings))
+        df = pd.DataFrame([listing.as_dict() for listing in listings])
+        if not df.empty:
+            df = df.drop_duplicates(subset=["listing_id", "url"], keep="first")
+        return df
+
+    def export_listings(
+        self, df: pd.DataFrame, output_path: Optional[str] = None, to_excel: bool = True
+    ) -> str:
+        output_path = output_path or str(
+            self.config.output_directory / "sahibinden_listings.xlsx"
+        )
+        path = export_dataframe(df, Path(output_path), to_excel=to_excel)
+        LOGGER.info("Exported %s listings to %s", len(df), path)
+        return str(path)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _fetch_page(self, filters: SearchFilters, page: int) -> List[Listing]:
+        """Fetch and parse a single result page."""
+
+        url = self._build_search_url(filters, page)
+        LOGGER.debug("Fetching page %s: %s", page, url)
+        html = self._perform_request(url)
+        listings = self._parse_listings(html)
+
+        if not listings and page == 1:
+            LOGGER.warning("İlk sayfada ilan bulunamadı.")
+        return listings
+
+    def _build_search_url(self, filters: SearchFilters, page: int) -> str:
+        query_params = filters.to_query_params()
+        query_params.update({"pagingOffset": (page - 1) * 20, "pagingSize": 20})
+
+        path = f"/{filters.listing_type}-{self.config.listing_path}"
+        url = urllib.parse.urljoin(self.config.base_url, path)
+        return f"{url}?{urllib.parse.urlencode(query_params)}"
+
+    def _perform_request(self, url: str) -> str:
+        if self.config.verify_robots and not self._is_allowed(url):
+            raise ScraperError("Robots.txt disallows scraping this resource.")
+
+        if self.config.use_selenium:
+            return self._fetch_with_selenium(url)
+
+        try:
+            response = self.session.get(
+                url,
+                timeout=20,
+                proxies=self.proxies.as_requests_proxies(),
+            )
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise ScraperError(f"HTTP isteği başarısız oldu: {exc}") from exc
+        if response.status_code == 429:
+            raise ScraperError("Received HTTP 429 (Too Many Requests). Slow down scraping.")
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:  # pragma: no cover - network errors
+            raise ScraperError(f"HTTP {response.status_code} hatası: {exc}") from exc
+        return response.text
+
+    def _fetch_with_selenium(self, url: str) -> str:
+        if webdriver is None or ChromeOptions is None:
+            raise ScraperError("Selenium is not installed but use_selenium=True.")
+
+        driver = self._ensure_driver()
+        try:
+            driver.get(url)
+            time.sleep(2)
+            return driver.page_source
+        except Exception as exc:  # noqa: BLE001
+            raise ScraperError(f"Selenium sayfayı yükleyemedi: {exc}") from exc
+
+    def _parse_listings(self, html: str) -> List[Listing]:
+        soup = BeautifulSoup(html, "html.parser")
+        table = soup.select_one("#searchResultsTable")
+        if table is None:
+            raise ScraperError(
+                "Sonuç tablosu bulunamadı. Site yapısı değişmiş olabilir."
+            )
+        rows = table.select("tbody tr")
+        listings: List[Listing] = []
+        for row in rows:
+            if "class" in row.attrs and "searchResultsPromo" in row["class"]:
+                continue
+            link = row.select_one("td.searchResultsTitleValue a")
+            if not link:
+                continue
+            listing_id = row.get("data-id") or link.get("href", "").split("-")[0]
+            title = link.get_text(strip=True)
+            price = row.select_one("td.searchResultsPriceValue").get_text(strip=True)
+            location = " ".join(
+                part.get_text(strip=True)
+                for part in row.select("td.searchResultsLocationValue *")
+            )
+            area_cell = row.select_one("td.searchResultsAttributeValue")
+            area = area_cell.get_text(strip=True) if area_cell else None
+            room_cell = row.select("td.searchResultsAttributeValue")
+            room = room_cell[1].get_text(strip=True) if len(room_cell) > 1 else None
+            publish_date = None
+            date_cell = row.select_one("td.searchResultsDateValue")
+            if date_cell:
+                publish_date = date_cell.get_text(strip=True)
+
+            seller = None
+            seller_cell = row.select_one("td.searchResultsOwnerTypeValue")
+            if seller_cell:
+                seller = seller_cell.get_text(strip=True)
+
+            photo_link = row.select_one("img")
+            photo_url = photo_link["src"] if photo_link and "src" in photo_link.attrs else None
+
+            url = urllib.parse.urljoin(self.config.base_url, link.get("href", ""))
+            listings.append(
+                Listing(
+                    listing_id=listing_id,
+                    title=title,
+                    price=price,
+                    location=location,
+                    area=area,
+                    room_count=room,
+                    url=url,
+                    publish_date=publish_date,
+                    seller=seller,
+                    photo_url=photo_url,
+                )
+            )
+        return listings
+
+    def _is_allowed(self, url: str) -> bool:
+        if not self.config.verify_robots:
+            return True
+        if not self._robots:
+            robots_url = urllib.parse.urljoin(self.config.base_url, "/robots.txt")
+            self._robots = urllib.robotparser.RobotFileParser()
+            self._robots.set_url(robots_url)
+            self._robots.read()
+        path = urllib.parse.urlparse(url).path
+        allowed = self._robots.can_fetch(self.config.user_agent, path)
+        if not allowed:
+            LOGGER.warning("Robots.txt disallows the path: %s", path)
+        return allowed
+
+    def _apply_rate_limit(self) -> None:
+        low, high = self.config.rate_limit_seconds
+        delay = random.uniform(low, high)
+        LOGGER.debug("Sleeping for %.2f seconds to respect rate limits", delay)
+        time.sleep(delay)
+
+    @staticmethod
+    def _should_skip_listing(listing: Listing, excluded_terms: Iterable[str]) -> bool:
+        if any_term_in_text(listing.title, excluded_terms):
+            return True
+        if listing.seller and any_term_in_text(listing.seller, excluded_terms):
+            return True
+        return False
+
+    def _ensure_driver(self):
+        if self._driver:
+            return self._driver
+
+        options = ChromeOptions()
+        options.add_argument("--headless=new")
+        options.add_argument("--disable-gpu")
+        options.add_argument(f"--user-agent={self.config.user_agent}")
+
+        proxy_url = self.proxies.http or self.proxies.https
+        if proxy_url:
+            options.add_argument(f"--proxy-server={proxy_url}")
+
+        self._driver = webdriver.Chrome(options=options)
+        return self._driver
+
+
+__all__ = ["Listing", "SahibindenScraper", "ScraperError"]

--- a/sahibinden_scraper/utils.py
+++ b/sahibinden_scraper/utils.py
@@ -1,0 +1,32 @@
+"""Shared helper functions for the scraping toolkit."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+
+def setup_logging(log_file: Path) -> None:
+    """Configure the root logger to emit to both console and a log file."""
+
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[
+            logging.FileHandler(log_file, encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+        force=True,
+    )
+
+
+def any_term_in_text(text: str, terms: Iterable[str]) -> bool:
+    """Return ``True`` when one of ``terms`` occurs in ``text`` (case-insensitive)."""
+
+    normalized = text.lower()
+    return any(term in normalized for term in terms)
+
+
+ProgressCallback = Callable[[int, Optional[int]], None]


### PR DESCRIPTION
## Summary
- add a modular `sahibinden_scraper` package with configuration, scraping, export, and logging helpers
- build a Tkinter-based GUI that supports filters, progress updates, proxy/headless options, and Excel export
- refresh the README and dependencies to document installation, usage, and new requirements

## Testing
- python -m compileall sahibinden_scraper

------
https://chatgpt.com/codex/tasks/task_e_690a3a0ebcc0832282d14b41d532fea6