### PR TITLE
Add Ilan Toplayici desktop scraper app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
-# Grok Free API
-This is unoffical free Grok OpenAI type API.  
-**This is unstable and may against grok TOS, use at your own risk!!**
-## setup
-Add your cookie in `main.py` first  
-```
-uv venv
-uv pip install -r requirements.txt
-git clone https://github.com/mem0ai/grok3-api.git
-cd ./grok3-api
-uv pip install .
-cd ..
-main.py
-```
-You can access it at `127.0.0.1:8046/v1`  
+# İlan Toplayıcı
+
+Bu depo, sahibinden.com için masaüstü veri toplayıcı uygulamasını içerir. Tam kaynak kod `ilan_toplayici/` klasöründe bulunur ve PySide6 + Playwright kullanır.
+
+Hızlı başlangıç için ayrıntılı yönergeler `ilan_toplayici/README.md` dosyasındadır.

--- a/ilan_toplayici/README.md
+++ b/ilan_toplayici/README.md
@@ -1,0 +1,61 @@
+# İlan Toplayıcı
+
+Sahibinden.com üzerindeki kendi oturumunuzu kullanarak manuel olarak erişebildiğiniz ilanları masaüstü üzerinden toplayan PySide6 + Playwright uygulaması.
+
+## Özellikler
+- Kendi Chrome/Edge oturumunuzu **kullanır**, e-posta/şifre istemez.
+- Listeleme sayfalarından ilan kartlarını okur, isteğe bağlı detay sayfasına girerek alanları çıkartır.
+- İlerleme ve logları canlı olarak gösterir; aynı ilanı iki kez işlemez.
+- Verileri Excel, CSV veya JSON olarak dışa aktarır.
+- Qt tabanlı masaüstü arayüz; scraping işlemi ayrı iş parçacığında çalışır.
+
+## Kurulum
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+python -m playwright install chrome
+```
+
+## Çalıştırma
+```bash
+python main.py
+```
+
+> İpucu: Açık olan Chrome/Edge oturumunuzdaki çerezi kullanmak için tarayıcıyı `--remote-debugging-port=9222` ile başlatıp ortam değişkeni `REMOTE_DEBUG_URL=http://localhost:9222` verebilirsiniz. Aksi halde Playwright kalıcı profil klasörü `.ilan_toplayici/profile` altında tutulur ve ilk açılışta manuel giriş yapabilirsiniz.
+
+## Paketleme (PyInstaller)
+```bash
+pyinstaller build.spec
+```
+Tek dosya exe çıktısı `dist/` klasöründe oluşur.
+
+## UI Akışı
+1. Kullanıcı sahibinden.com'a kendi tarayıcısıyla giriş yapar.
+2. "Listeleme URL" alanına filtreli ilan listesini yapıştırır; sayfa sayısı ve gecikme değerlerini belirler.
+3. "Başlat" ile tarama sürecini izler; dilerse "Durdur" ile temiz şekilde kapatır.
+4. Tablo güncellenen ilan satırlarını gösterir; alt bölümde sayaçlar ve log akışı bulunur.
+5. Excel/CSV/JSON butonlarıyla sonuçlar dışa aktarılır.
+
+## Hata Senaryoları ve Log Örnekleri
+- Ağ veya selector hatası: `Kritik hata: TimeoutError` gibi satırlar log penceresinde gösterilir, süreç diğer ilanlarla devam eder.
+- İlan detayında telefon görünmezse: satır "Telefon" kolonunda boş kalır, istenirse "Sadece iletişim" filtresiyle elenir.
+- Sonraki sayfa tıklama sorunları: `Sonraki sayfaya geçerken hata: ...` mesajı loga düşer.
+
+## Dosya Yapısı
+```
+/ilan_toplayici
+  /app
+    main.py         # Qt uygulama giriş noktası
+    ui_main.py      # UI düzeni ve model
+    scraper.py      # Playwright QThread işçisi
+    parser.py       # Selector bazlı alan çıkarma
+    exporter.py     # Excel/CSV/JSON dışa aktarım
+    storage.py      # In-memory + sqlite cache
+    models.py       # Veri modelleri
+    utils.py        # Yardımcı araçlar
+  requirements.txt
+  README.md
+  build.spec
+  assets/
+```

--- a/ilan_toplayici/app/exporter.py
+++ b/ilan_toplayici/app/exporter.py
@@ -1,0 +1,38 @@
+"""Export helpers for saving scraped data."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+
+def export_excel(df: pd.DataFrame, path: Path) -> Path:
+    if df.empty:
+        raise ValueError("Export verisi boş")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with pd.ExcelWriter(path, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False)
+        sheet = writer.sheets[writer.sheet_names[0]]
+        for col_cells in sheet.columns:
+            max_len = max(len(str(cell.value)) if cell.value else 0 for cell in col_cells)
+            sheet.column_dimensions[col_cells[0].column_letter].width = max(12, max_len + 2)
+        for cell in sheet[1]:
+            cell.font = cell.font.copy(bold=True)
+    return path
+
+
+def export_csv(df: pd.DataFrame, path: Path) -> Path:
+    if df.empty:
+        raise ValueError("Export verisi boş")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False, encoding="utf-8")
+    return path
+
+
+def export_json(df: pd.DataFrame, path: Path) -> Path:
+    if df.empty:
+        raise ValueError("Export verisi boş")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_json(path, orient="records", force_ascii=False, indent=2)
+    return path

--- a/ilan_toplayici/app/main.py
+++ b/ilan_toplayici/app/main.py
@@ -1,0 +1,87 @@
+"""Entry point for the İlân Toplayıcı desktop app."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pandas as pd
+from PySide6 import QtCore, QtWidgets
+
+from .exporter import export_csv, export_excel, export_json
+from .models import ScrapeConfig
+from .scraper import ScraperWorker
+from .storage import InMemoryStorage
+from .ui_main import PandasModel, UiMainWindow
+from .utils import Paths, setup_logger
+
+
+class AppController(QtCore.QObject):
+    def __init__(self, window: UiMainWindow, paths: Paths) -> None:
+        super().__init__()
+        self.window = window
+        self.paths = paths
+        self.storage = InMemoryStorage()
+        self.model = PandasModel(self.storage.dataframe)
+        self.window.set_model(self.model)
+        self.scraper: ScraperWorker | None = None
+        self.logger = setup_logger()
+
+        self.window.start_requested.connect(self.start_scraping)
+        self.window.stop_requested.connect(self.stop_scraping)
+        self.window.export_requested.connect(self.export_data)
+
+    def start_scraping(self, config: ScrapeConfig) -> None:
+        if self.scraper and self.scraper.isRunning():
+            return
+        config.user_data_dir = self.paths.profile_dir
+        config.remote_debugging_url = os.environ.get("REMOTE_DEBUG_URL")
+        self.window.toggle_run_state(True)
+        self.storage.reset()
+        self.model.update(self.storage.dataframe)
+        self.scraper = ScraperWorker(config, self.storage)
+        self.scraper.log_message.connect(self.window.append_log)
+        self.scraper.progress.connect(self.window.update_stats)
+        self.scraper.row_ready.connect(self._on_row_ready)
+        self.scraper.finished.connect(self._on_finished)
+        self.scraper.start()
+        self.window.append_log("Tarama başladı. Lütfen açık olan tarayıcı oturumunuzun kullanıldığından emin olun.")
+
+    def stop_scraping(self) -> None:
+        if self.scraper:
+            self.scraper.stop()
+            self.window.append_log("Durdurma talebi gönderildi.")
+
+    def _on_row_ready(self, row: dict) -> None:
+        df = self.storage.dataframe
+        self.model.update(df)
+        self.window.table_view.resizeColumnsToContents()
+
+    def _on_finished(self) -> None:
+        self.window.toggle_run_state(False)
+        self.window.append_log("Tarama tamamlandı.")
+
+    def export_data(self, fmt: str) -> None:
+        df = self.storage.dataframe
+        try:
+            if fmt == "excel":
+                path = export_excel(df, self.paths.export_dir / "ilanlar.xlsx")
+            elif fmt == "csv":
+                path = export_csv(df, self.paths.export_dir / "ilanlar.csv")
+            else:
+                path = export_json(df, self.paths.export_dir / "ilanlar.json")
+            self.window.append_log(f"Dışa aktarıldı: {path}")
+        except Exception as exc:  # pylint: disable=broad-except
+            QtWidgets.QMessageBox.warning(self.window, "Export Hatası", str(exc))
+
+
+def main() -> None:
+    app = QtWidgets.QApplication(sys.argv)
+    paths = Paths.default()
+    window = UiMainWindow()
+    controller = AppController(window, paths)
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/ilan_toplayici/app/models.py
+++ b/ilan_toplayici/app/models.py
@@ -1,0 +1,96 @@
+"""Data models for the scraping workflow."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class ScrapeConfig:
+    listing_url: str
+    max_pages: int
+    min_delay: float
+    max_delay: float
+    fetch_details: bool
+    only_with_contact: bool
+    category_hint: Optional[str] = None
+    user_data_dir: Optional[Path] = None
+    remote_debugging_url: Optional[str] = None
+
+
+@dataclass
+class ListingRecord:
+    ilan_no: Optional[str]
+    baslik: str
+    fiyat: Optional[str]
+    metrekare: Optional[str]
+    konum: Optional[str]
+    il: Optional[str]
+    ilce: Optional[str]
+    mahalle: Optional[str]
+    ilan_tarihi: Optional[str]
+    ilan_tipi: Optional[str]
+    tur: Optional[str]
+    ilan_sahibi_tipi: Optional[str]
+    ilan_sahibi_adi: Optional[str]
+    telefon: Optional[str]
+    mesaj: Optional[str]
+    link: str
+    aciklama: Optional[str] = None
+    profil_link: Optional[str] = None
+
+    @classmethod
+    def headers(cls) -> List[str]:
+        return [
+            "İlan No",
+            "Başlık",
+            "Fiyat",
+            "m²",
+            "İl",
+            "İlçe",
+            "Mahalle",
+            "İlan Tarihi",
+            "İlan Tipi",
+            "Tür",
+            "İlan Sahibi Tipi",
+            "İlan Sahibi / Ofis",
+            "Telefon",
+            "Mesajlaşma Var mı",
+            "Link",
+            "Açıklama",
+            "Profil Linki",
+        ]
+
+    def as_row(self) -> Dict[str, Optional[str]]:
+        return {
+            "İlan No": self.ilan_no or "",
+            "Başlık": self.baslik,
+            "Fiyat": self.fiyat or "",
+            "m²": self.metrekare or "",
+            "İl": self.il or "",
+            "İlçe": self.ilce or "",
+            "Mahalle": self.mahalle or "",
+            "İlan Tarihi": self.ilan_tarihi or "",
+            "İlan Tipi": self.ilan_tipi or "",
+            "Tür": self.tur or "",
+            "İlan Sahibi Tipi": self.ilan_sahibi_tipi or "",
+            "İlan Sahibi / Ofis": self.ilan_sahibi_adi or "",
+            "Telefon": self.telefon or "",
+            "Mesajlaşma Var mı": self.mesaj or "",
+            "Link": self.link,
+            "Açıklama": self.aciklama or "",
+            "Profil Linki": self.profil_link or "",
+        }
+
+
+@dataclass
+class ScrapeStats:
+    total_found: int = 0
+    processed: int = 0
+    failed: int = 0
+    remaining: int = 0
+    log_lines: List[str] = field(default_factory=list)
+
+    def as_progress_tuple(self) -> tuple[int, int, int, int]:
+        return self.total_found, self.processed, self.failed, self.remaining

--- a/ilan_toplayici/app/parser.py
+++ b/ilan_toplayici/app/parser.py
@@ -1,0 +1,181 @@
+"""Parsing helpers for sahibinden.com pages using Playwright."""
+from __future__ import annotations
+
+from typing import List
+
+from playwright.async_api import Locator, Page
+
+from .models import ListingRecord
+
+
+async def extract_listing_cards(page: Page) -> List[dict]:
+    """Collect listing card metadata from the current listing page."""
+    cards: List[dict] = []
+    candidate_selectors = [
+        "div.searchResultsItem",
+        "tr.searchResultsItem",
+        "div[class*='classified']",
+    ]
+    locator: Locator | None = None
+    for selector in candidate_selectors:
+        loc = page.locator(selector)
+        if await loc.count() > 0:
+            locator = loc
+            break
+    if locator is None:
+        return cards
+
+    count = await locator.count()
+    for idx in range(count):
+        item = locator.nth(idx)
+        link = await _safe_inner_attr(item, "a", "href")
+        title = await _safe_inner_text(item, "a")
+        price = await _safe_inner_text(item, "[class*='price']")
+        location = await _safe_inner_text(item, "[class*='location']")
+        ilan_no = await _safe_inner_text(item, "[data-id]")
+        if link:
+            cards.append(
+                {
+                    "link": link,
+                    "baslik": title or "(Başlıksız)",
+                    "fiyat": price,
+                    "konum": location,
+                    "ilan_no": ilan_no,
+                }
+            )
+    return cards
+
+
+async def parse_detail_page(page: Page, summary: dict) -> ListingRecord:
+    """Extract detail fields with defensive selectors."""
+    ilan_no = await _first_text(page, ["text=İlan No", "xpath=//li[contains(text(),'İlan No')]"])
+    ilan_tarihi = await _first_text(
+        page,
+        [
+            "text=İlan Tarihi",
+            "xpath=//li[contains(text(),'İlan Tarihi')]",
+            "css=div.classifiedInfo li:has-text('İlan Tarihi')",
+        ],
+    )
+    metrekare = await _first_text(page, ["text=m²", "xpath=//li[contains(text(),'m²')]"])
+    address = await _first_text(
+        page,
+        [
+            "css=div.classifiedInfo li:has-text('Adres')",
+            "css=div.address",
+            "css=div[class*='location']",
+        ],
+    )
+    seller_type = await _first_text(page, ["text=Emlak Ofisi", "text=Bireysel"])
+    seller_name = await _first_text(page, ["css=div.classifiedUserContent h3", "css=div.userName"])
+    message_available = "Var" if await _element_exists(page, "text=Mesaj Gönder") else "Yok"
+    phone_number = await _first_text(page, ["css=button.phone", "css=a[href^='tel']"])
+    profile_link = await _first_attr(page, ["css=div.classifiedUserContent a", "css=a.userLink"], "href")
+    description = await _first_text(page, ["css=#classifiedDescription", "css=.classifiedDescription"])
+
+    il = ilce = mahalle = None
+    if address and "," in address:
+        parts = [p.strip() for p in address.split(",")]
+        if len(parts) >= 1:
+            il = parts[-1]
+        if len(parts) >= 2:
+            ilce = parts[-2]
+        if len(parts) >= 3:
+            mahalle = parts[-3]
+
+    return ListingRecord(
+        ilan_no=ilan_no or summary.get("ilan_no"),
+        baslik=summary.get("baslik", "(Başlıksız)"),
+        fiyat=summary.get("fiyat"),
+        metrekare=metrekare,
+        konum=summary.get("konum"),
+        il=il,
+        ilce=ilce,
+        mahalle=mahalle,
+        ilan_tarihi=ilan_tarihi,
+        ilan_tipi=summary.get("ilan_tipi"),
+        tur=summary.get("tur"),
+        ilan_sahibi_tipi=seller_type,
+        ilan_sahibi_adi=seller_name,
+        telefon=phone_number,
+        mesaj=message_available,
+        link=summary.get("link", ""),
+        aciklama=description,
+        profil_link=profile_link,
+    )
+
+
+async def summary_to_record(summary: dict) -> ListingRecord:
+    return ListingRecord(
+        ilan_no=summary.get("ilan_no"),
+        baslik=summary.get("baslik", "(Başlıksız)"),
+        fiyat=summary.get("fiyat"),
+        metrekare=None,
+        konum=summary.get("konum"),
+        il=None,
+        ilce=None,
+        mahalle=None,
+        ilan_tarihi=None,
+        ilan_tipi=summary.get("ilan_tipi"),
+        tur=summary.get("tur"),
+        ilan_sahibi_tipi=None,
+        ilan_sahibi_adi=None,
+        telefon=None,
+        mesaj=None,
+        link=summary.get("link", ""),
+    )
+
+
+async def _first_text(page: Page, selectors: list[str]) -> str | None:
+    for selector in selectors:
+        try:
+            el = page.locator(selector).first
+            if await el.count() > 0:
+                text = await el.inner_text()
+                if text:
+                    return text.strip()
+        except Exception:
+            continue
+    return None
+
+
+async def _first_attr(page: Page, selectors: list[str], attr: str) -> str | None:
+    for selector in selectors:
+        try:
+            el = page.locator(selector).first
+            if await el.count() > 0:
+                val = await el.get_attribute(attr)
+                if val:
+                    return val.strip()
+        except Exception:
+            continue
+    return None
+
+
+async def _element_exists(page: Page, selector: str) -> bool:
+    try:
+        return await page.locator(selector).count() > 0
+    except Exception:
+        return False
+
+
+async def _safe_inner_text(locator: Locator, selector: str) -> str | None:
+    try:
+        target = locator.locator(selector)
+        if await target.count() == 0:
+            return None
+        text = await target.first.inner_text()
+        return text.strip()
+    except Exception:
+        return None
+
+
+async def _safe_inner_attr(locator: Locator, selector: str, attr: str) -> str | None:
+    try:
+        target = locator.locator(selector)
+        if await target.count() == 0:
+            return None
+        value = await target.first.get_attribute(attr)
+        return value.strip() if value else None
+    except Exception:
+        return None

--- a/ilan_toplayici/app/scraper.py
+++ b/ilan_toplayici/app/scraper.py
@@ -1,0 +1,130 @@
+"""Playwright-powered scraper that runs inside a QThread."""
+from __future__ import annotations
+
+import asyncio
+import traceback
+from datetime import datetime
+from typing import List, Optional
+
+from PySide6 import QtCore
+from playwright.async_api import async_playwright
+
+from .models import ListingRecord, ScrapeConfig, ScrapeStats
+from .parser import extract_listing_cards, parse_detail_page, summary_to_record
+from .storage import InMemoryStorage
+from .utils import DEFAULT_TIMEOUT, random_delay_seconds
+
+
+class ScraperWorker(QtCore.QThread):
+    log_message = QtCore.Signal(str)
+    progress = QtCore.Signal(int, int, int, int)
+    row_ready = QtCore.Signal(dict)
+    finished = QtCore.Signal()
+
+    def __init__(self, config: ScrapeConfig, storage: InMemoryStorage, parent: Optional[QtCore.QObject] = None):
+        super().__init__(parent)
+        self.config = config
+        self.storage = storage
+        self._stop = False
+        self.stats = ScrapeStats()
+
+    def run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(self._run())
+        finally:
+            loop.close()
+
+    async def _run(self) -> None:
+        self.stats = ScrapeStats()
+        try:
+            async with async_playwright() as p:
+                browser = await self._create_browser(p)
+                page = await browser.new_page()
+                await page.goto(self.config.listing_url, wait_until="domcontentloaded", timeout=DEFAULT_TIMEOUT)
+                await page.wait_for_timeout(1500)
+
+                for page_no in range(1, self.config.max_pages + 1):
+                    if self._stop:
+                        break
+                    await self._scrape_listing_page(page, page_no)
+
+                    next_selector = "a[rel='next'], a.next-prev"
+                    has_next = await page.locator(next_selector).count() > 0
+                    if page_no < self.config.max_pages and has_next:
+                        try:
+                            await page.locator(next_selector).first.click()
+                            await page.wait_for_load_state("domcontentloaded")
+                            await page.wait_for_timeout(1200)
+                        except Exception as exc:
+                            self._emit_log(f"Sonraki sayfaya geçerken hata: {exc}")
+                            break
+                    else:
+                        break
+
+                await browser.close()
+        except Exception as exc:  # pylint: disable=broad-except
+            tb = traceback.format_exc()
+            self._emit_log(f"Kritik hata: {exc}\n{tb}")
+        finally:
+            self.finished.emit()
+
+    def stop(self) -> None:
+        self._stop = True
+
+    async def _scrape_listing_page(self, page, page_index: int) -> None:
+        summaries = await extract_listing_cards(page)
+        self.stats.total_found += len(summaries)
+        self.stats.remaining = self.stats.total_found - self.stats.processed
+        self._emit_progress()
+        for summary in summaries:
+            if self._stop:
+                break
+            record = await self._process_summary(page, summary)
+            if record and self.storage.add_record(record):
+                self.stats.processed += 1
+                self.stats.remaining = max(self.stats.total_found - self.stats.processed, 0)
+                self.row_ready.emit(record.as_row())
+            else:
+                self.stats.failed += 1
+            self._emit_progress()
+            delay = random_delay_seconds(self.config.min_delay, self.config.max_delay)
+            await page.wait_for_timeout(int(delay * 1000))
+        self._emit_log(f"Sayfa {page_index} tamamlandı ({len(summaries)} ilan).")
+
+    async def _process_summary(self, page, summary: dict) -> Optional[ListingRecord]:
+        try:
+            if self.config.fetch_details and summary.get("link"):
+                await page.goto(summary["link"], wait_until="domcontentloaded", timeout=DEFAULT_TIMEOUT)
+                await page.wait_for_timeout(900)
+                record = await parse_detail_page(page, summary)
+                if self.config.only_with_contact and not record.telefon:
+                    return None
+                return record
+            record = await summary_to_record(summary)
+            if self.config.only_with_contact:
+                return None
+            return record
+        except Exception as exc:  # pylint: disable=broad-except
+            self._emit_log(f"İlan işlenirken hata: {exc}")
+            return None
+
+    async def _create_browser(self, playwright):
+        chromium = playwright.chromium
+        if self.config.remote_debugging_url:
+            return await chromium.connect_over_cdp(self.config.remote_debugging_url)
+        return await chromium.launch_persistent_context(
+            user_data_dir=str(self.config.user_data_dir),
+            headless=False,
+            channel="chrome",
+        )
+
+    def _emit_log(self, message: str) -> None:
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        full_message = f"[{timestamp}] {message}"
+        self.stats.log_lines.append(full_message)
+        self.log_message.emit(full_message)
+
+    def _emit_progress(self) -> None:
+        self.progress.emit(*self.stats.as_progress_tuple())

--- a/ilan_toplayici/app/storage.py
+++ b/ilan_toplayici/app/storage.py
@@ -1,0 +1,88 @@
+"""In-memory storage layer with optional sqlite cache."""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable, Optional
+
+import pandas as pd
+
+from .models import ListingRecord
+
+
+class InMemoryStorage:
+    """Keep scraped items in a pandas DataFrame and track duplicates."""
+
+    def __init__(self) -> None:
+        self._records: list[ListingRecord] = []
+        self._seen: set[str] = set()
+
+    @property
+    def dataframe(self) -> pd.DataFrame:
+        if not self._records:
+            return pd.DataFrame(columns=ListingRecord.headers())
+        return pd.DataFrame([rec.as_row() for rec in self._records])
+
+    def add_record(self, record: ListingRecord) -> bool:
+        key = record.ilan_no or record.link
+        if key in self._seen:
+            return False
+        self._seen.add(key)
+        self._records.append(record)
+        return True
+
+    def reset(self) -> None:
+        self._records.clear()
+        self._seen.clear()
+
+    def extend(self, records: Iterable[ListingRecord]) -> int:
+        count = 0
+        for rec in records:
+            if self.add_record(rec):
+                count += 1
+        return count
+
+
+class SqliteCache:
+    """Optional lightweight cache for listing metadata."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS listings (
+                    ilan_no TEXT PRIMARY KEY,
+                    link TEXT,
+                    updated_at TEXT,
+                    payload TEXT
+                )
+                """
+            )
+
+    def upsert(self, record: ListingRecord, updated_at: str) -> None:
+        payload = asdict(record)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO listings (ilan_no, link, updated_at, payload)
+                VALUES (?, ?, ?, json(?))
+                ON CONFLICT(ilan_no) DO UPDATE SET
+                    link=excluded.link,
+                    updated_at=excluded.updated_at,
+                    payload=excluded.payload
+                """,
+                (record.ilan_no, record.link, updated_at, payload),
+            )
+
+    def exists(self, ilan_no: Optional[str]) -> bool:
+        if not ilan_no:
+            return False
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute("SELECT 1 FROM listings WHERE ilan_no=?", (ilan_no,))
+            return cursor.fetchone() is not None

--- a/ilan_toplayici/app/ui_main.py
+++ b/ilan_toplayici/app/ui_main.py
@@ -1,0 +1,186 @@
+"""Main window UI built with PySide6."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pandas as pd
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from .models import ListingRecord, ScrapeConfig
+
+
+class PandasModel(QtCore.QAbstractTableModel):
+    def __init__(self, df: pd.DataFrame, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self._df = df.copy()
+
+    def update(self, df: pd.DataFrame) -> None:
+        self.beginResetModel()
+        self._df = df.copy()
+        self.endResetModel()
+
+    def rowCount(self, parent: QtCore.QModelIndex = QtCore.QModelIndex()) -> int:  # type: ignore[override]
+        return len(self._df.index)
+
+    def columnCount(self, parent: QtCore.QModelIndex = QtCore.QModelIndex()) -> int:  # type: ignore[override]
+        return len(self._df.columns)
+
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.DisplayRole) -> Any:  # type: ignore[override]
+        if not index.isValid() or role not in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole):
+            return None
+        value = self._df.iat[index.row(), index.column()]
+        return str(value) if value is not None else ""
+
+    def headerData(self, section: int, orientation: QtCore.Qt.Orientation, role: int = QtCore.Qt.DisplayRole):  # type: ignore[override]
+        if role != QtCore.Qt.DisplayRole:
+            return None
+        if orientation == QtCore.Qt.Horizontal:
+            return str(self._df.columns[section])
+        return str(section + 1)
+
+
+class UiMainWindow(QtWidgets.QMainWindow):
+    start_requested = QtCore.Signal(ScrapeConfig)
+    stop_requested = QtCore.Signal()
+    export_requested = QtCore.Signal(str)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("İlan Toplayıcı")
+        self.resize(1200, 720)
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self) -> None:
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        content_layout = QtWidgets.QHBoxLayout()
+
+        # Left panel
+        self.url_edit = QtWidgets.QLineEdit()
+        self.url_edit.setPlaceholderText("Sahibinden listeleme URL'si")
+        self.category_combo = QtWidgets.QComboBox()
+        self.category_combo.addItems(["(Belirtme)", "Satılık", "Kiralık", "Ev", "Arsa"])
+        self.max_pages = QtWidgets.QSpinBox()
+        self.max_pages.setRange(1, 200)
+        self.max_pages.setValue(5)
+        self.delay_min = QtWidgets.QDoubleSpinBox()
+        self.delay_min.setRange(0, 30)
+        self.delay_min.setDecimals(1)
+        self.delay_min.setValue(1.0)
+        self.delay_max = QtWidgets.QDoubleSpinBox()
+        self.delay_max.setRange(0, 60)
+        self.delay_max.setDecimals(1)
+        self.delay_max.setValue(3.0)
+        self.fetch_details = QtWidgets.QCheckBox("Detay sayfasına gir")
+        self.fetch_details.setChecked(True)
+        self.only_contact = QtWidgets.QCheckBox("Sadece iletişim bilgisi olanlar")
+        self.start_btn = QtWidgets.QPushButton("Başlat")
+        self.stop_btn = QtWidgets.QPushButton("Durdur")
+        self.stop_btn.setEnabled(False)
+
+        form_layout = QtWidgets.QFormLayout()
+        form_layout.addRow("Listeleme URL", self.url_edit)
+        form_layout.addRow("Kategori", self.category_combo)
+        form_layout.addRow("Max sayfa", self.max_pages)
+        form_layout.addRow("Gecikme (sn) min", self.delay_min)
+        form_layout.addRow("Gecikme (sn) max", self.delay_max)
+        form_layout.addRow(self.fetch_details)
+        form_layout.addRow(self.only_contact)
+        form_layout.addRow(self.start_btn)
+        form_layout.addRow(self.stop_btn)
+
+        left_panel = QtWidgets.QGroupBox("Ayarlar")
+        left_panel.setLayout(form_layout)
+
+        # Center table
+        self.table_view = QtWidgets.QTableView()
+        self.table_view.setSortingEnabled(True)
+
+        # Bottom log
+        log_container = QtWidgets.QGroupBox("Log")
+        log_layout = QtWidgets.QVBoxLayout()
+        self.log_text = QtWidgets.QPlainTextEdit()
+        self.log_text.setReadOnly(True)
+        stats_layout = QtWidgets.QHBoxLayout()
+        self.total_label = QtWidgets.QLabel("Toplam: 0")
+        self.processed_label = QtWidgets.QLabel("İşlenen: 0")
+        self.failed_label = QtWidgets.QLabel("Hatalı: 0")
+        self.remaining_label = QtWidgets.QLabel("Kalan: 0")
+        stats_layout.addWidget(self.total_label)
+        stats_layout.addWidget(self.processed_label)
+        stats_layout.addWidget(self.failed_label)
+        stats_layout.addWidget(self.remaining_label)
+        stats_layout.addStretch()
+        self.progress_bar = QtWidgets.QProgressBar()
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setValue(0)
+        export_buttons = QtWidgets.QHBoxLayout()
+        self.export_excel_btn = QtWidgets.QPushButton("Excel")
+        self.export_csv_btn = QtWidgets.QPushButton("CSV")
+        self.export_json_btn = QtWidgets.QPushButton("JSON")
+        export_buttons.addWidget(self.export_excel_btn)
+        export_buttons.addWidget(self.export_csv_btn)
+        export_buttons.addWidget(self.export_json_btn)
+        export_buttons.addStretch()
+
+        log_layout.addWidget(self.log_text)
+        log_layout.addLayout(stats_layout)
+        log_layout.addWidget(self.progress_bar)
+        log_layout.addLayout(export_buttons)
+        log_container.setLayout(log_layout)
+
+        content_layout.addWidget(left_panel, 1)
+        content_layout.addWidget(self.table_view, 3)
+
+        layout.addLayout(content_layout)
+        layout.addWidget(log_container)
+        self.setCentralWidget(central)
+
+    def _connect_signals(self) -> None:
+        self.start_btn.clicked.connect(self._on_start)
+        self.stop_btn.clicked.connect(lambda: self.stop_requested.emit())
+        self.export_excel_btn.clicked.connect(lambda: self.export_requested.emit("excel"))
+        self.export_csv_btn.clicked.connect(lambda: self.export_requested.emit("csv"))
+        self.export_json_btn.clicked.connect(lambda: self.export_requested.emit("json"))
+
+    def set_model(self, model: PandasModel) -> None:
+        self.table_view.setModel(model)
+
+    def _on_start(self) -> None:
+        if not self.url_edit.text():
+            QtWidgets.QMessageBox.warning(self, "Uyarı", "Listeleme URL'si zorunludur")
+            return
+        config = ScrapeConfig(
+            listing_url=self.url_edit.text().strip(),
+            max_pages=int(self.max_pages.value()),
+            min_delay=float(self.delay_min.value()),
+            max_delay=float(self.delay_max.value()),
+            fetch_details=self.fetch_details.isChecked(),
+            only_with_contact=self.only_contact.isChecked(),
+            category_hint=self.category_combo.currentText() if self.category_combo.currentIndex() > 0 else None,
+        )
+        self.start_requested.emit(config)
+
+    # UI update helpers
+    def append_log(self, message: str) -> None:
+        self.log_text.appendPlainText(message)
+        self.log_text.verticalScrollBar().setValue(self.log_text.verticalScrollBar().maximum())
+
+    def update_stats(self, total: int, processed: int, failed: int, remaining: int) -> None:
+        self.total_label.setText(f"Toplam: {total}")
+        self.processed_label.setText(f"İşlenen: {processed}")
+        self.failed_label.setText(f"Hatalı: {failed}")
+        self.remaining_label.setText(f"Kalan: {remaining}")
+        total_items = max(total, processed + failed + remaining)
+        percent = int((processed / total_items) * 100) if total_items else 0
+        self.progress_bar.setValue(percent)
+
+    def toggle_run_state(self, running: bool) -> None:
+        self.start_btn.setEnabled(not running)
+        self.stop_btn.setEnabled(running)
+
+    def populate_table(self, df: pd.DataFrame, model: PandasModel) -> None:
+        model.update(df)
+        self.table_view.resizeColumnsToContents()
+        self.table_view.resizeRowsToContents()

--- a/ilan_toplayici/app/utils.py
+++ b/ilan_toplayici/app/utils.py
@@ -1,0 +1,61 @@
+"""Utility helpers for logging, configuration, and timing."""
+from __future__ import annotations
+
+import logging
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+LOG_FORMAT = "[%(asctime)s] %(levelname)s - %(message)s"
+
+
+def setup_logger(log_file: Optional[Path] = None) -> logging.Logger:
+    """Configure application logger.
+
+    Args:
+        log_file: Optional file path to write log output.
+
+    Returns:
+        Configured logger instance.
+    """
+    logger = logging.getLogger("ilan_toplayici")
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        formatter = logging.Formatter(LOG_FORMAT)
+
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
+
+        if log_file:
+            file_handler = logging.FileHandler(log_file)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+    return logger
+
+
+def random_delay_seconds(min_delay: float, max_delay: float) -> float:
+    """Return a random delay between boundaries."""
+    min_d = max(min_delay, 0)
+    max_d = max(max_delay, min_d)
+    return random.uniform(min_d, max_d)
+
+
+@dataclass
+class Paths:
+    base_dir: Path
+    profile_dir: Path
+    export_dir: Path
+
+    @classmethod
+    def default(cls, base: Optional[Path] = None) -> "Paths":
+        base_dir = base or Path.home() / ".ilan_toplayici"
+        export_dir = base_dir / "exports"
+        profile_dir = base_dir / "profile"
+        export_dir.mkdir(parents=True, exist_ok=True)
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        return cls(base_dir=base_dir, profile_dir=profile_dir, export_dir=export_dir)
+
+
+DEFAULT_TIMEOUT = 25_000

--- a/ilan_toplayici/build.spec
+++ b/ilan_toplayici/build.spec
@@ -1,0 +1,42 @@
+# PyInstaller spec for İlan Toplayıcı
+block_cipher = None
+
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='ilan_toplayici',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='ilan_toplayici'
+)

--- a/ilan_toplayici/requirements.txt
+++ b/ilan_toplayici/requirements.txt
@@ -1,0 +1,5 @@
+PySide6==6.7.1
+playwright==1.44.0
+pandas==2.2.2
+openpyxl==3.1.2
+numpy==1.26.4

--- a/main.py
+++ b/main.py
@@ -1,52 +1,5 @@
-from fastapi import FastAPI, HTTPException
-from fastapi.encoders import jsonable_encoder
-from grok_client import GrokClient
-
-app = FastAPI()
-
-# Your cookie values (Paste all cookies you can find in F12)
-cookies = {
-    "x-anonuserid": "ffdd32e1",
-    "x-challenge": "TkC4D..",
-    "x-signature": "fJ0...",
-    "sso": "ey..."
-}
-
-# Initialize the client
-client = GrokClient(cookies)
-
-@app.get("/v1/models")
-async def get_models():
-    try:
-        models = ["grok-3"]
-        return jsonable_encoder(models)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-@app.post("/v1/chat/completions")
-async def create_completion(request: dict):
-    try:
-        data = request
-        
-        # model = data.get('model', 'grok-3')
-        messages = data.get('messages', [])
-        # temperature = data.get('temperature', 1.0)
-        
-        if not messages:
-            raise HTTPException(status_code=400, detail="Messages are required")
-        
-        response = client.send_message(messages)
-        
-        return {
-            "choices": [{
-                "message": {
-                    "content": response
-                }
-            }]
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+"""Launcher for the İlân Toplayıcı desktop application."""
+from ilan_toplayici.app.main import main
 
 if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8046)
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-fastapi
-uvicorn
+-r ilan_toplayici/requirements.txt


### PR DESCRIPTION
## Summary
- add PySide6 desktop interface for the İlan Toplayıcı tool with scraping controls and table view
- implement Playwright-based scraper with defensive parsing, progress reporting, and export helpers
- document setup, packaging, and usage for the new Windows-friendly project structure

## Testing
- python -m compileall ilan_toplayici


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694705f351e48322a52a2b2d25caa675)